### PR TITLE
Fix double-slash in derived OIDC metadata URL

### DIFF
--- a/docs/assets/local/modules/configuration/NewProvider.js
+++ b/docs/assets/local/modules/configuration/NewProvider.js
@@ -19,12 +19,19 @@ export class NewProvider extends ModalDialog {
         const form = section.querySelector("form");
         form.elements["fetch"].addEventListener("click", async e => {
             const url = new URL(form.elements["issuer"].value);
-            url.pathname = url.pathname + "/.well-known/openid-configuration";
+            // Some browsers use pathname="/" even if the original URL had no trailing slash
+            if (!url.pathname.endsWith("/")) {
+                url.pathname += "/.well-known/openid-configuration";
+            } else {
+                url.pathname += ".well-known/openid-configuration";
+            }
             let json = {};
             try {
                 json = await http_get(url);
-            } catch {
-                // TODO: show error
+            } catch(e) {
+                alert("Failed to fetch issuer metadata from " + url); // TODO: show better error
+                console.error(e);
+                return;
             }
             this.set_metadata(JSON.stringify(json, null, 2));
             this.json_to_form(json);


### PR DESCRIPTION
First of all thanks for the nice OIDC testing tool. Making good use of it :)

There's a small thing I noticed: it cannot fetch the OIDC issuer metadata from my local testing issuer (http://localhost:1234) because it derives the OIDC metadata URL `http://localhost:1234//.well-known/oidc-configuration`. The reason seems to be that at least in Firefox, `url.pathname` is `/` for `uri = new URI("http://localhost:1234")`.

This small change aims to fix that (and uses a low-tech alert to show fetch issues).