### PR TITLE
Allow saving login-hint with client configuration.

### DIFF
--- a/docs/assets/local/modules/configuration/NewClient.js
+++ b/docs/assets/local/modules/configuration/NewClient.js
@@ -13,6 +13,7 @@ export class NewClient extends ModalDialog {
             "redirect_uris",
             "initiate_login_uri",
             "scope",
+            "login_hint",
         ];
     }
     async create_popup(section) {

--- a/docs/assets/local/modules/tester/Authorization.js
+++ b/docs/assets/local/modules/tester/Authorization.js
@@ -36,6 +36,7 @@ export class Authorization {
         form.elements["redirect_uri"].setAttribute("pattern", redirect_uri_pattern(client));
         form.elements["redirect_uri"].setAttribute("title", redirect_uri_title(client));
         form.elements["scope"].value = client.scope || "openid";
+        form.elements["login_hint"].value = client.login_hint || "";
         if ("code_challenge_methods_supported" in issuer) {
             this.new_code_challenge("S256");
         }

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -234,6 +234,10 @@
                 <input class="flex1" type="text" placeholder="scope" name="scope" />
             </label>
             <label>
+                <span>login_hint</span>
+                <input class="flex1" type="text" placeholder="login_hint" name="login_hint" />
+            </label>
+            <label>
                 <span>client_uri</span>
                 <input class="flex1" type="text" placeholder="client_uri" name="client_uri" />
             </label>


### PR DESCRIPTION
It would be very useful to be able to save a login_hint with the client configuration. Certain providers, such as Auth0, enable what they call Identifier-First authentication flows (https://auth0.com/docs/authenticate/login/auth0-universal-login/identifier-first). It piggy-backs of the OIDC standard `login_hint` parameter. When testing such flows, setting the `login_hint` needs to be set in order to avoid having to manually enter it on the provider's side. Allowing us to save the login_hint with client configuration would avoid having to continuously input this for every test.